### PR TITLE
Fix $vm.prev() 的 bug

### DIFF
--- a/src/swipe.vue
+++ b/src/swipe.vue
@@ -203,7 +203,7 @@
           }
           if (prevPage) {
             prevPage.style.display = 'block';
-            translate(nextPage, -pageWidth);
+            translate(prevPage, -pageWidth);
           }
           if (nextPage) {
             nextPage.style.display = 'block';


### PR DESCRIPTION
直接调用 $vm.prev() 的时候，动效会有 bug。
经查是这里的问题。
